### PR TITLE
Improve accessibility for screen reader users on desktop and mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 	<body onload="onload()">
 		<div id="menu">
 			<button id="toggle" onclick="toggle_menu()" aria-pressed="false"><img src="assets/menu.svg" alt="menu"></img></button>
-			<div id="menucontent" role="group" aria-labelledby="toggle">
+			<div id="menucontent" role="group" aria-labelledby="toggle" onkeyup="menu_onkeyup(event)">
 				<button onclick="import_metadata()" id="bt_import">Import</button>
 				<button onclick="export_metadata()" id="bt_export">Export</button>
 				<button onclick="show_tutorial()" id="bt_tutorial">Tutorial</button>

--- a/index.html
+++ b/index.html
@@ -37,9 +37,9 @@
 			<button id="input_clear" onclick="input_clear()">X</button>
 		</div>
 		<div id="item_list">
-			<p id="buy_title" class="section_title">Buy</p>
+			<p id="buy_title" class="section_title" role="heading" aria-level="3">Buy</p>
 			<div id="current_items"></div>
-			<p id="last_title" class="section_title">Last used</p>
+			<p id="last_title" class="section_title" role="heading" aria-level="3">Last used</p>
 			<div id="last_items"></div>
 		<div>
 	</body>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 	</head>
 	<body onload="onload()">
 		<div id="menu">
-			<button id="toggle" onclick="toggle_menu()"><img src="assets/menu.svg"></img></button>
+			<button id="toggle" onclick="toggle_menu()"><img src="assets/menu.svg" alt="menu"></img></button>
 			<div id="menucontent">
 				<button onclick="import_metadata()" id="bt_import">Import</button>
 				<button onclick="export_metadata()" id="bt_export">Export</button>

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
 	</head>
 	<body onload="onload()">
 		<div id="menu">
-			<button id="toggle" onclick="toggle_menu()"><img src="assets/menu.svg" alt="menu"></img></button>
-			<div id="menucontent">
+			<button id="toggle" onclick="toggle_menu()" aria-pressed="false"><img src="assets/menu.svg" alt="menu"></img></button>
+			<div id="menucontent" role="group" aria-labelledby="toggle">
 				<button onclick="import_metadata()" id="bt_import">Import</button>
 				<button onclick="export_metadata()" id="bt_export">Export</button>
 				<button onclick="show_tutorial()" id="bt_tutorial">Tutorial</button>
@@ -38,9 +38,9 @@
 		</div>
 		<div id="item_list">
 			<p id="buy_title" class="section_title" role="heading" aria-level="3">Buy</p>
-			<div id="current_items"></div>
+			<div id="current_items" role="group" aria-labelledby="buy_title"></div>
 			<p id="last_title" class="section_title" role="heading" aria-level="3">Last used</p>
-			<div id="last_items"></div>
+			<div id="last_items" role="group" aria-labelledby="last_title"></div>
 		<div>
 	</body>
 </html>

--- a/js/list.js
+++ b/js/list.js
@@ -86,6 +86,7 @@ class Item
     }
 
     var delete_timer = -1;
+    var start_keyPress = 0;
 
     function startPress()
     {
@@ -126,11 +127,41 @@ class Item
         clearInterval(delete_timer);
       }, 1000);
     }
+    function startKeyPress(event)
+    {
+      if (event.key == "Enter" || event.key == "Space")
+      {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!start_keyPress)
+        {
+          start_keyPress = (new Date()).getTime();
+        } else {
+          return;
+        }
+        startPress();
+      }
+    }
     function cancelPress()
     {
       if (delete_timer != -1)
       {
         clearInterval(delete_timer);
+      }
+    }
+    function cancelKeyPress(event)
+    {
+      if (event.key == "Enter" || event.key == "Space")
+      {
+        event.preventDefault();
+        event.stopPropagation();
+        var delta = (new Date()).getTime() - start_keyPress;
+        if (delta <= 100)
+        {
+          event.target.click();
+        }
+        cancelPress();
+        start_keyPress = 0;
       }
     }
     this.dom.addEventListener("mousedown", startPress);
@@ -139,6 +170,8 @@ class Item
     this.dom.addEventListener("touchstart", startPress);
     this.dom.addEventListener("touchend", cancelPress);
     this.dom.addEventListener("touchcancel", cancelPress);
+    this.dom.addEventListener("keydown", startKeyPress);
+    this.dom.addEventListener("keyup", cancelKeyPress);
   }
 }
 
@@ -161,6 +194,12 @@ function input_onkeydown(obj, event)
 {
   if (obj.value != "" && event.key == "Enter")
   {
+  if (obj.value == name_backup)
+  {
+    event.preventDefault();
+    event.stopPropagation();
+    return;
+  }
     editing = false;
     add_item(obj.value.trim());
     obj.value = "";

--- a/js/menu.js
+++ b/js/menu.js
@@ -1,15 +1,18 @@
 function toggle_menu()
 {
   var obj = document.getElementById("menucontent");
+  var button = document.getElementById("toggle");
   if (!document.getElementById("menu").classList.contains("menu_open"))
   {
     document.getElementById("menu").classList.add("menu_open");
     document.getElementById("menu").classList.remove("menu_close");
+    button.setAttribute("aria-pressed", true);
   }
   else
   {
     document.getElementById("menu").classList.add("menu_close");
     document.getElementById("menu").classList.remove("menu_open");
+    button.setAttribute("aria-pressed", false);
   }
 }
 

--- a/js/menu.js
+++ b/js/menu.js
@@ -94,3 +94,12 @@ function show_tutorial()
 {
   window.location.replace("/tutorial.html");
 }
+
+function menu_onkeyup(event)
+{
+  if (event.key == "Escape")
+  {
+    toggle_menu();
+    document.getElementById("toggle").focus();
+  }
+}

--- a/js/popup.js
+++ b/js/popup.js
@@ -23,7 +23,8 @@ class traero_popup
     var dom = document.createElement("div");
     this.dom = dom;
     dom.id = "popup";
-    var bt_close = document.createElement("button");
+    dom.setAttribute("onkeyup", "popup_onkeyup(event)");
+var bt_close = document.createElement("button");
     bt_close.id = "bt_close";
     bt_close.innerHTML = "X";
     bt_close.onclick = function()
@@ -36,12 +37,17 @@ class traero_popup
       var txt_title = document.createElement("p");
       this._title = txt_title;
       txt_title.id = "title";
+      txt_title.setAttribute("role", "heading");
+      txt_title.setAttribute("aria-level", 2);
       txt_title.innerHTML = title;
       dom.appendChild(txt_title);
     }
     var content = document.createElement("div");
     this.content = content;
     content.id = "content";
+    content.setAttribute("role", "dialog");
+    content.setAttribute("aria-labelledby", "title");
+    content.setAttribute("tabindex", -1);
     dom.appendChild(content);
     for (var i in classes)
     {
@@ -56,6 +62,7 @@ function show_popup(title=undefined)
 {
   var frame = document.createElement("div");
   frame.id = "popup";
+  frame.setAttribute("onkeyup", "popup_onkeyup(event)");
   var bt_close = document.createElement("button");
   bt_close.id = "bt_close";
   bt_close.innerHTML = "X";
@@ -68,12 +75,26 @@ function show_popup(title=undefined)
   {
     var txt_title = document.createElement("p");
     txt_title.id = "title";
+    txt_title.setAttribute("role", "heading");
+    txt_title.setAttribute("aria-level", 2);
     txt_title.innerHTML = title;
     frame.appendChild(txt_title);
   }
   var content = document.createElement("div");
   content.id = "content";
+  content.setAttribute("role", "dialog");
+  content.setAttribute("tabindex", -1);
+  content.setAttribute("aria-labelledby", "title");
   frame.appendChild(content);
   document.body.appendChild(frame);
   return content;
+}
+
+function popup_onkeyup(event)
+{
+  if (event.key == "Escape")
+  {
+    document.getElementById("bt_close").click();
+    document.getElementById("new_item_input").focus();
+  }
 }

--- a/js/toast.js
+++ b/js/toast.js
@@ -8,6 +8,7 @@ function traero_toast(msg, mstime, closeable=false, button_onclick=undefined)
   toast.appendChild(timer_ui);
   var text = document.createElement("p");
   text.id = "message";
+  text.role = "alert";
   text.innerHTML = msg;
   toast.appendChild(text);
   if (closeable)

--- a/tutorial.html
+++ b/tutorial.html
@@ -20,10 +20,10 @@
 			<button id="input_clear" onclick="input_clear()">X</button>
 		</div>
 		<div id="item_list">
-			<p id="buy_title" class="section_title">Buy</p>
-			<div id="current_items"></div>
-			<p id="last_title" class="section_title">Last used</p>
-			<div id="last_items"></div>
+			<p id="buy_title" class="section_title" role="heading" aria-level="3">Buy</p>
+			<div id="current_items" aria-labelledby="buy_title"></div>
+			<p id="last_title" class="section_title" role="heading" aria-level="3">Last used</p>
+			<div id="last_items" aria-labelledby="last_title"></div>
 		<div>
 	</body>
 </html>


### PR DESCRIPTION
It brings the following improvements:

* Report list titles as heading at level 3 (usefull for screen reader users on mobile so they can quickly jump from active to the recent list).
* Label the lists (usefull for desktop users, so the screen reader announces they are moving out of active into the recent list and the other way round when navigating with the tab or shift+tab key).
* Label the menu button, also report its state and allow exiting the menu by pressing the escape key.
* Add an ability to move items by short pressing space or enter keys and editing or deleting items by long pressing space or enter keys essentially making this app usefull for keyboard only users.
* Add an ability to dismiss popups with the escape key and label them for easier identification while navigating into / out of them with a screen reader running.